### PR TITLE
Consistency and modularity

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -1,12 +1,6 @@
 cmake_minimum_required(VERSION 3.21)
 project(Brainfuck C)
 
-set(CMAKE_C_FLAGS "-Wall -Wextra")
+set(CMAKE_C_FLAGS "-Wall -Wextra -Werror=implicit-function-declaration -Werror=incompatible-pointer-types -Werror=return-type")
 
-if (CMAKE_SYSTEM_NAME MATCHES "Windows")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4013 /we4133 /we4716")
-elseif (CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME MATCHES "Darwin")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=implicit-function-declaration -Werror=incompatible-pointer-types -Werror=return-type")
-endif()
-
-add_executable(Brainfuck src/main.c src/brainfuck_interpreter.h src/brainfuck_interpreter.c src/util.h)
+add_executable(Brainfuck src/main.c src/brainfuck_interpreter.h src/brainfuck_interpreter.c src/util.h src/util.c)

--- a/c/src/brainfuck_interpreter.h
+++ b/c/src/brainfuck_interpreter.h
@@ -3,7 +3,6 @@
 
 #include <stdint.h>
 
-
 typedef struct {
     size_t memory_size;
     size_t instruction_size;

--- a/c/src/brainfuck_interpreter.h
+++ b/c/src/brainfuck_interpreter.h
@@ -3,20 +3,17 @@
 
 #include <stdint.h>
 
-#define DEFAULT_TAPE_SIZE 30000
 
-typedef struct {;
+typedef struct {
     size_t memory_size;
     size_t instruction_size;
     uint8_t* memory;
-    uint8_t* cell;
+    uint8_t* memory_pointer;
     char* instructions;
-    char* curr_instruction;
+    char* instruction_pointer;
 } InterpreterState;
 
-InterpreterState* create_interpreter(const char* filename);
-
-void reset_interpreter(InterpreterState* interpreter, const char* filename);
+InterpreterState* create_interpreter(size_t initial_memory_size, char* instructions, size_t instruction_size);
 
 int interpret_code(InterpreterState* interpreter);
 

--- a/c/src/main.c
+++ b/c/src/main.c
@@ -1,9 +1,15 @@
 #include <stdio.h>
-
 #include "brainfuck_interpreter.h"
+#include "util.h"
 
 int main() {
-    InterpreterState* interpreter = create_interpreter("program.bf");
+    char* instructions = 0;
+    size_t instruction_size = 0;
+    if(read_file("program.bf", &instructions, &instruction_size) == EXIT_FAILURE) {
+        return EXIT_FAILURE;
+    }
+
+    InterpreterState* interpreter = create_interpreter(3000, instructions, instruction_size);
     interpret_code(interpreter);
     return 0;
 }

--- a/c/src/util.c
+++ b/c/src/util.c
@@ -1,0 +1,30 @@
+#include "util.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int read_file(const char* path, char** content, size_t* contentSize) {
+    FILE* file = fopen(path, "r");
+
+    if(file == NULL) {
+        fprintf(stderr,"[ERROR] Failed to open file %s", path);
+        return EXIT_FAILURE;
+    }
+
+    fseek(file, 0, SEEK_END);
+    *contentSize = ftell(file);
+    rewind(file);
+
+    if(*contentSize == -1ull) {
+        fprintf(stderr, "[ERROR] Failed to get file size of file %s", path);
+        return EXIT_FAILURE;
+    }
+
+    free(*content);
+    *content = calloc(*contentSize + 1, sizeof(char));
+    fread(*content, sizeof(char), *contentSize, file);
+
+    fclose(file);
+
+    return EXIT_SUCCESS;
+}

--- a/c/src/util.h
+++ b/c/src/util.h
@@ -1,42 +1,8 @@
 #ifndef BRAINFUCK_UTIL_H
 #define BRAINFUCK_UTIL_H
 
-#include <stdio.h>
 #include <stdlib.h>
 
-static inline int read_file(const char* path, char** content, size_t* contentSize) {
-    FILE* file = fopen(path, "r");
-
-    if(file == NULL) {
-        printf("[ERROR] Failed to open file");
-        return EXIT_FAILURE;
-    }
-
-    fseek(file, 0, SEEK_END);
-    *contentSize = ftell(file);
-    rewind(file);
-
-    if(*contentSize == -1ull) {
-        printf("[ERROR] Failed to extract file size");
-        return EXIT_FAILURE;
-    }
-
-    free(*content);
-    *content = calloc(*contentSize + 1, sizeof(char));
-    fread(*content, sizeof(char), *contentSize, file);
-
-    fclose(file);
-
-    return EXIT_SUCCESS;
-}
-
-inline void clear_console() {
-#if defined(_WIN32)
-    system("cls");
-#endif
-#if defined(__linux__) || defined(__unix__) || defined(__APPLE__)
-    system("clear");
-#endif
-}
+int read_file(const char* path, char** content, size_t* contentSize);
 
 #endif //BRAINFUCK_UTIL_H


### PR DESCRIPTION
- moved read_file from util.h to util.c,
  static inline from function removed,
  include of stdio moved to util.c: this way *.c files which include util.h do not automatically include stdio
- removed clear_console function from util.h (unused)
- print errors to stderr instead of stdout
- renamed cell to memory_pointer and curr_instruction to instruction_pointer for consistency
- removed reset_interpreter function (unused, a new interpreter can just be created)
- automatic ide code reformat